### PR TITLE
update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'checkstyle'
-    id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.ben-manes.versions' version '0.27.0'
     id 'java-library'
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.4.3'
+version '2.0.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11
@@ -147,15 +147,15 @@ ext {
     javaxValidationVersion = '2.0.0.Final'
     junit = '5.7.0'
     lombokVersion = '1.18.16'
-    mapstruct = '1.2.0.Final'
-    springCloudVersion = 'Greenwich.SR2'
-    springVersion = '2.1.14.RELEASE'
+    mapstruct = '1.4.2.Final'
+    springCloudVersion = '2020.0.1'
+    springVersion = '2.4.2'
     swaggerVersion = '1.5.20'
     wiremock = '2.24.1'
     wiremockJunit5 = '1.3.0'
 }
 
-ext["spring-cloud-openfeign.version"] = "2.1.2.RELEASE"
+ext["spring-cloud-openfeign.version"] = "3.0.1"
 
 dependencyManagement {
     imports {
@@ -198,7 +198,7 @@ dependencies {
     compileOnly group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonDatabind
     compileOnly group: 'org.mapstruct', name: 'mapstruct-processor', version: mapstruct
     annotationProcessor("org.mapstruct:mapstruct-processor:${mapstruct}")
-    implementation group: 'org.mapstruct', name: 'mapstruct-jdk8', version: mapstruct
+    implementation group: 'org.mapstruct', name: 'mapstruct', version: mapstruct
 }
 
 wrapper {


### PR DESCRIPTION
Update to Spring 2.4, Spring Cloud 2020.0.1 and Spring open feign 3.0.1.

I have bumped the version to 2.0.0 because I believe this will break with things that use Spring 2.3 or Spring open feign < 3.0.0